### PR TITLE
Save XMM registers between exits and fix bug in NtCreateFileHook

### DIFF
--- a/gbhv/entry.c
+++ b/gbhv/entry.c
@@ -15,7 +15,7 @@ NTSTATUS DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING RegistryPath)
 	
 	DriverObject->DriverUnload = DriverUnload;
 
-	HvUtilLog("--------------------------------------------------------------");
+	HvUtilLog("--------------------------------------------------------------\n");
 
 	GlobalContext = HvInitializeAllProcessors();
 
@@ -53,11 +53,11 @@ VOID NTAPI ExitRootModeOnAllProcessors(_In_ struct _KDPC *Dpc,
 	// Initialize processor for VMX
 	if (VmxExitRootMode(CurrentContext))
 	{
-		HvUtilLogDebug("ExitRootModeOnAllProcessors[#%i]: Exiting VMX mode.", CurrentProcessorNumber);
+		HvUtilLogDebug("ExitRootModeOnAllProcessors[#%i]: Exiting VMX mode.\n", CurrentProcessorNumber);
 	}
 	else
 	{
-		HvUtilLogError("ExitRootModeOnAllProcessors[#%i]: Failed to exit VMX mode.", CurrentProcessorNumber);
+		HvUtilLogError("ExitRootModeOnAllProcessors[#%i]: Failed to exit VMX mode.\n", CurrentProcessorNumber);
 	}
 
 	// These must be called for GenericDpcCall to signal other processors

--- a/gbhv/exit.c
+++ b/gbhv/exit.c
@@ -78,7 +78,7 @@ VOID HvExitHandleEptMisconfiguration(PVMM_PROCESSOR_CONTEXT ProcessorContext, PV
 {
 	UNREFERENCED_PARAMETER(ProcessorContext);
 
-	HvUtilLogError("EPT Misconfiguration! A field in the EPT paging structure was invalid. Faulting guest address: 0x%llX", ExitContext->GuestPhysicalAddress);
+	HvUtilLogError("EPT Misconfiguration! A field in the EPT paging structure was invalid. Faulting guest address: 0x%llX\n", ExitContext->GuestPhysicalAddress);
 
 	ExitContext->ShouldIncrementRIP = FALSE;
 	ExitContext->ShouldStopExecution = TRUE;
@@ -91,7 +91,7 @@ VOID HvExitHandleUnknownExit(PVMM_PROCESSOR_CONTEXT ProcessorContext, PVMEXIT_CO
 	UNREFERENCED_PARAMETER(ProcessorContext);
 
 	__debugbreak();
-	HvUtilLogError("Unknown exit reason! An exit was made but no handler was configured to handle it. Reason: 0x%llX", ExitContext->ExitReason.BasicExitReason);
+	HvUtilLogError("Unknown exit reason! An exit was made but no handler was configured to handle it. Reason: 0x%llX\n", ExitContext->ExitReason.BasicExitReason);
 
 	// Try to keep executing, despite the unknown exit.
 	ExitContext->ShouldIncrementRIP = TRUE;
@@ -144,7 +144,7 @@ BOOL HvExitDispatchFunction(PVMM_PROCESSOR_CONTEXT ProcessorContext, PVMEXIT_CON
 
 	if (ExitContext->ShouldStopExecution)
 	{
-		HvUtilLogError("HvExitDispatchFunction: Leaving VMX mode.");
+		HvUtilLogError("HvExitDispatchFunction: Leaving VMX mode.\n");
 		return FALSE;
 	}
 

--- a/gbhv/gbhv.vcxproj
+++ b/gbhv/gbhv.vcxproj
@@ -42,7 +42,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>gbhv</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/gbhv/os_nt.c
+++ b/gbhv/os_nt.c
@@ -40,7 +40,7 @@ PVOID OsAllocateContiguousAlignedPages(SIZE_T NumberOfPages)
 
 	if(Output == NULL)
 	{
-		HvUtilLogError("OsAllocateContiguousAlignedPages: Out of memory!");
+		HvUtilLogError("OsAllocateContiguousAlignedPages: Out of memory!\n");
 	}
 
 	return Output;
@@ -67,7 +67,7 @@ PVOID OsAllocateNonpagedMemory(SIZE_T NumberOfBytes)
 
 	if (Output == NULL)
 	{
-		HvUtilLogError("OsAllocateNonpagedMemory: Out of memory!");
+		HvUtilLogError("OsAllocateNonpagedMemory: Out of memory!\n");
 	}
 
 	return Output;
@@ -86,7 +86,7 @@ PVOID OsAllocateExecutableNonpagedMemory(SIZE_T NumberOfBytes)
 
 	if (Output == NULL)
 	{
-		HvUtilLogError("OsAllocateExecutableNonpagedMemory: Out of memory!");
+		HvUtilLogError("OsAllocateExecutableNonpagedMemory: Out of memory!\n");
 	}
 
 	return Output;

--- a/gbhv/vmcs.c
+++ b/gbhv/vmcs.c
@@ -25,11 +25,11 @@ BOOL HvSetupVmcsDefaults(PVMM_PROCESSOR_CONTEXT Context, SIZE_T HostRIP, SIZE_T 
 
 	// Setup all of the control fields of the VMCS
 	VmError |= HvSetupVmcsControlFields(Context);
-	HvUtilLogDebug("HvSetupVmcsControlFields: VmError = %i", VmError);
+	HvUtilLogDebug("HvSetupVmcsControlFields: VmError = %i\n", VmError);
 
 	if(VmError != 0)
 	{
-		HvUtilLogError("HvSetupVmcsControlFields: VmError = %i", VmError);
+		HvUtilLogError("HvSetupVmcsControlFields: VmError = %i\n", VmError);
 		return FALSE;
 	}
 		
@@ -38,7 +38,7 @@ BOOL HvSetupVmcsDefaults(PVMM_PROCESSOR_CONTEXT Context, SIZE_T HostRIP, SIZE_T 
 
 	if (VmError != 0)
 	{
-		HvUtilLogError("HvSetupVmcsGuestArea: VmError = %i", VmError);
+		HvUtilLogError("HvSetupVmcsGuestArea: VmError = %i\n", VmError);
 		return FALSE;
 	}
 
@@ -47,7 +47,7 @@ BOOL HvSetupVmcsDefaults(PVMM_PROCESSOR_CONTEXT Context, SIZE_T HostRIP, SIZE_T 
 
 	if (VmError != 0)
 	{
-		HvUtilLogError("HvSetupVmcsHostArea: VmError = %i", VmError);
+		HvUtilLogError("HvSetupVmcsHostArea: VmError = %i\n", VmError);
 		return FALSE;
 	}
 
@@ -262,7 +262,7 @@ VMX_ERROR HvSetupVmcsGuestArea(PVMM_PROCESSOR_CONTEXT Context, SIZE_T GuestRIP, 
 
 	// TODO: Totally refactor segmentation setup
 
-	HvUtilLogDebug("GdtRegister: 0x%llx, Base: 0x%llx, Limit: 0x%llx", GdtRegister, GdtRegister.BaseAddress, GdtRegister.Limit);
+	HvUtilLogDebug("GdtRegister: 0x%llx, Base: 0x%llx, Limit: 0x%llx\n", GdtRegister, GdtRegister.BaseAddress, GdtRegister.Limit);
 
 	VMCS_SETUP_GUEST_SEGMENTATION(ES, Registers->SegES);
 	VMCS_SETUP_GUEST_SEGMENTATION(CS, Registers->SegCS);

--- a/gbhv/vmm.c
+++ b/gbhv/vmm.c
@@ -23,12 +23,12 @@ PVMM_CONTEXT HvInitializeAllProcessors()
     SIZE_T FeatureMSR;
     PVMM_CONTEXT GlobalContext;
 
-    HvUtilLog("HvInitializeAllProcessors: Starting.");
+    HvUtilLog("HvInitializeAllProcessors: Starting.\n");
 
     // Check if VMX support is enabled on the processor.
     if (!ArchIsVMXAvailable())
     {
-        HvUtilLogError("VMX is not a feture of this processor.");
+        HvUtilLogError("VMX is not a feture of this processor.\n");
         return NULL;
     }
 
@@ -38,7 +38,7 @@ PVMM_CONTEXT HvInitializeAllProcessors()
     // The BIOS will lock the VMX bit on startup.
     if (!HvUtilBitIsSet(FeatureMSR, FEATURE_BIT_VMX_LOCK))
     {
-        HvUtilLogError("VMX support was not locked by BIOS.");
+        HvUtilLogError("VMX support was not locked by BIOS.\n");
         return NULL;
     }
 
@@ -46,11 +46,11 @@ PVMM_CONTEXT HvInitializeAllProcessors()
     // Check to ensure this isn't the case.
     if (!HvUtilBitIsSet(FeatureMSR, FEATURE_BIT_ALLOW_VMX_OUTSIDE_SMX))
     {
-        HvUtilLogError("VMX support was disabled outside of SMX operation by BIOS.");
+        HvUtilLogError("VMX support was disabled outside of SMX operation by BIOS.\n");
         return NULL;
     }
 
-    HvUtilLog("Total Processor Count: %i", OsGetCPUCount());
+    HvUtilLog("Total Processor Count: %i\n", OsGetCPUCount());
 
     // Pre-allocate all logical processor contexts, VMXON regions, VMCS regions
     GlobalContext = HvAllocateVmmContext();
@@ -62,7 +62,7 @@ PVMM_CONTEXT HvInitializeAllProcessors()
 
 	if (!HvEptGlobalInitialize(GlobalContext))
 	{
-		HvUtilLogError("Processor does not support all necessary EPT features.");
+		HvUtilLogError("Processor does not support all necessary EPT features.\n");
 		HvFreeVmmContext(GlobalContext);
 		return NULL;
 	}
@@ -73,12 +73,12 @@ PVMM_CONTEXT HvInitializeAllProcessors()
     if (GlobalContext->SuccessfulInitializationsCount != OsGetCPUCount())
     {
         // TODO: Move to driver uninitalization
-        HvUtilLogError("HvInitializeAllProcessors: Not all processors initialized. [%i successful]", GlobalContext->SuccessfulInitializationsCount);
+        HvUtilLogError("HvInitializeAllProcessors: Not all processors initialized. [%i successful]\n", GlobalContext->SuccessfulInitializationsCount);
 		HvFreeVmmContext(GlobalContext);
         return NULL;
     }
 
-    HvUtilLogSuccess("HvInitializeAllProcessors: Success.");
+    HvUtilLogSuccess("HvInitializeAllProcessors: Success.\n");
     return GlobalContext;
 }
 
@@ -131,15 +131,15 @@ PVMM_CONTEXT HvAllocateVmmContext()
         ProcessorContexts[ProcessorNumber] = HvAllocateLogicalProcessorContext(Context);
         if (ProcessorContexts[ProcessorNumber] == NULL)
         {
-            HvUtilLogError("HvInitializeLogicalProcessor[#%i]: Failed to setup processor context.", ProcessorNumber);
+            HvUtilLogError("HvInitializeLogicalProcessor[#%i]: Failed to setup processor context.\n", ProcessorNumber);
             return NULL;
         }
 
-        HvUtilLog("HvInitializeLogicalProcessor[#%i]: Allocated Context [Context = 0x%llx]", ProcessorNumber, ProcessorContexts[ProcessorNumber]);
+        HvUtilLog("HvInitializeLogicalProcessor[#%i]: Allocated Context [Context = 0x%llx]\n", ProcessorNumber, ProcessorContexts[ProcessorNumber]);
     }
 
     Context->AllProcessorContexts = ProcessorContexts;
-    HvUtilLog("VmcsRevisionNumber: %x", Context->VmxCapabilities.VmcsRevisionId);
+    HvUtilLog("VmcsRevisionNumber: %x\n", Context->VmxCapabilities.VmcsRevisionId);
 
     return Context;
 }
@@ -354,7 +354,7 @@ VOID NTAPI HvpDPCBroadcastFunction(_In_ struct _KDPC *Dpc,
     }
     else
     {
-        HvUtilLogError("HvpDPCBroadcastFunction[#%i]: Failed to VMLAUNCH.", CurrentProcessorNumber);
+        HvUtilLogError("HvpDPCBroadcastFunction[#%i]: Failed to VMLAUNCH.\n", CurrentProcessorNumber);
     }
 
     // These must be called for GenericDpcCall to signal other processors
@@ -384,7 +384,7 @@ VOID HvInitializeLogicalProcessor(PVMM_PROCESSOR_CONTEXT Context, SIZE_T GuestRS
     // Enable VMXe, execute VMXON and enter VMX root mode
     if (!VmxEnterRootMode(Context))
     {
-        HvUtilLogError("HvInitializeLogicalProcessor[#%i]: Failed to enter VMX Root Mode.", CurrentProcessorNumber);
+        HvUtilLogError("HvInitializeLogicalProcessor[#%i]: Failed to enter VMX Root Mode.\n", CurrentProcessorNumber);
         return;
     }
 
@@ -392,7 +392,7 @@ VOID HvInitializeLogicalProcessor(PVMM_PROCESSOR_CONTEXT Context, SIZE_T GuestRS
     // &Context->HostStack.GlobalContext is also the top of the host stack
     if (!HvSetupVmcsDefaults(Context, (SIZE_T)&HvEnterFromGuest, (SIZE_T)&Context->HostStack.GlobalContext, GuestRIP, GuestRSP))
     {
-        HvUtilLogError("HvInitializeLogicalProcessor[#%i]: Failed to enter VMX Root Mode.", CurrentProcessorNumber);
+        HvUtilLogError("HvInitializeLogicalProcessor[#%i]: Failed to enter VMX Root Mode.\n", CurrentProcessorNumber);
         VmxExitRootMode(Context);
         return;
     }
@@ -401,7 +401,7 @@ VOID HvInitializeLogicalProcessor(PVMM_PROCESSOR_CONTEXT Context, SIZE_T GuestRS
     // on the guest.
     if (!VmxLaunchProcessor(Context))
     {
-        HvUtilLogError("HvInitializeLogicalProcessor[#%i]: Failed to VmxLaunchProcessor.", CurrentProcessorNumber);
+        HvUtilLogError("HvInitializeLogicalProcessor[#%i]: Failed to VmxLaunchProcessor.\n", CurrentProcessorNumber);
         return;
     }
 }
@@ -473,7 +473,7 @@ BOOL HvHandleVmExit(PVMM_CONTEXT GlobalContext, PGPREGISTER_CONTEXT GuestRegiste
     if(!Success)
     {
 		// TODO: More information
-		HvUtilLogError("Failed to handle exit.");
+		HvUtilLogError("Failed to handle exit.\n");
     }
 
     /*

--- a/gbhv/vmx.c
+++ b/gbhv/vmx.c
@@ -8,7 +8,7 @@
  */
 BOOL VmxLaunchProcessor(PVMM_PROCESSOR_CONTEXT Context)
 {
-    HvUtilLogDebug("VmxLaunchProcessor: VMLAUNCH....");
+    HvUtilLogDebug("VmxLaunchProcessor: VMLAUNCH....\n");
 
     // Launch the VMCS! If this returns, there was an error.
     // Otherwise, execution continues in guest_resumes_here from vmxdefs.asm
@@ -37,11 +37,11 @@ VOID VmxPrintErrorState(PVMM_PROCESSOR_CONTEXT Context)
     // Read the failure code
     if (__vmx_vmread(VMCS_VM_INSTRUCTION_ERROR, &FailureCode) != 0)
     {
-        HvUtilLogError("VmxPrintErrorState: Failed to read error code.");
+        HvUtilLogError("VmxPrintErrorState: Failed to read error code.\n");
         return;
     }
 
-    HvUtilLogError("VmxPrintErrorState: VMLAUNCH Error = 0x%llx", FailureCode);
+    HvUtilLogError("VmxPrintErrorState: VMLAUNCH Error = 0x%llx\n", FailureCode);
 }
 
 /*
@@ -90,27 +90,27 @@ BOOL VmxEnterRootMode(PVMM_PROCESSOR_CONTEXT Context)
     // Ensure the required fixed bits are set in cr0 and cr4, as per the spec.
     VmxSetFixedBits();
 
-    HvUtilLogDebug("VmxOnRegion[#%i]: (V) 0x%llx / (P) 0x%llx [%i]", OsGetCurrentProcessorNumber(), Context->VmxonRegion, Context->VmxonRegionPhysical, (PUINT32)Context->VmxonRegion->VmcsRevisionNumber);
+    HvUtilLogDebug("VmxOnRegion[#%i]: (V) 0x%llx / (P) 0x%llx [%i]\n", OsGetCurrentProcessorNumber(), Context->VmxonRegion, Context->VmxonRegionPhysical, (PUINT32)Context->VmxonRegion->VmcsRevisionNumber);
 
     // Execute VMXON to bring processor to VMX mode
     // Check RFLAGS.CF == 0 to ensure successful execution
     if (__vmx_on((ULONGLONG *)&Context->VmxonRegionPhysical) != 0)
     {
-        HvUtilLogError("VMXON failed.");
+        HvUtilLogError("VMXON failed.\n");
         return FALSE;
     }
 
     // And clear the VMCS before writing the configuration entries to it
     if (__vmx_vmclear((ULONGLONG *)&Context->VmcsRegionPhysical) != 0)
     {
-        HvUtilLogError("VMCLEAR failed.");
+        HvUtilLogError("VMCLEAR failed.\n");
         return FALSE;
     }
 
     // Now load the blank VMCS
     if (__vmx_vmptrld((ULONGLONG *)&Context->VmcsRegionPhysical) != 0)
     {
-        HvUtilLogError("VMPTRLD failed.");
+        HvUtilLogError("VMPTRLD failed.\n");
         return FALSE;
     }
 
@@ -127,12 +127,12 @@ BOOL VmxEnterRootMode(PVMM_PROCESSOR_CONTEXT Context)
  */
 BOOL VmxExitRootMode(PVMM_PROCESSOR_CONTEXT Context)
 {
-	HvUtilLogError("Exiting VMX.");
+	HvUtilLogError("Exiting VMX.\n");
 
     // Clear the VMCS before VMXOFF (Specification requires this)
     if (__vmx_vmclear((ULONGLONG *)&Context->VmcsRegionPhysical) != 0)
     {
-        HvUtilLogError("VMCLEAR failed.");
+        HvUtilLogError("VMCLEAR failed.\n");
     }
 
     // Turn off VMX

--- a/gbhv/vmxdefs.asm
+++ b/gbhv/vmxdefs.asm
@@ -127,11 +127,11 @@ HvEnterFromGuest PROC
 	; or a #GP exception is generated.
 	sub rsp, 68h
 	movaps xmmword ptr [rsp], xmm0
-	movaps xmmword ptr [rsp + 10h], xmm1
-	movaps xmmword ptr [rsp + 20h], xmm2
-	movaps xmmword ptr [rsp + 30h], xmm3
-	movaps xmmword ptr [rsp + 40h], xmm4
-	movaps xmmword ptr [rsp + 50h], xmm5
+	movaps xmmword ptr [rsp+10h], xmm1
+	movaps xmmword ptr [rsp+20h], xmm2
+	movaps xmmword ptr [rsp+30h], xmm3
+	movaps xmmword ptr [rsp+40h], xmm4
+	movaps xmmword ptr [rsp+50h], xmm5
 
 	; Call HvHandleVmExit to actually handle the
 	; incoming exit
@@ -139,13 +139,13 @@ HvEnterFromGuest PROC
 	call HvHandleVmExit
 	add rsp, 20h
 
-	; Restore SSE registers
+	; Restore XMM registers
 	movaps xmm0, xmmword ptr [rsp]
-	movaps xmm1, xmmword ptr [rsp + 10h]
-	movaps xmm2, xmmword ptr [rsp + 20h]
-	movaps xmm3, xmmword ptr [rsp + 30h]
-	movaps xmm4, xmmword ptr [rsp + 40h]
-	movaps xmm5, xmmword ptr [rsp + 50h]
+	movaps xmm1, xmmword ptr [rsp+10h]
+	movaps xmm2, xmmword ptr [rsp+20h]
+	movaps xmm3, xmmword ptr [rsp+30h]
+	movaps xmm4, xmmword ptr [rsp+40h]
+	movaps xmm5, xmmword ptr [rsp+50h]
 	add rsp, 68h
 
 	; If it's not successful, we need to stop and figure out why

--- a/gbhv/vmxdefs.asm
+++ b/gbhv/vmxdefs.asm
@@ -123,11 +123,30 @@ HvEnterFromGuest PROC
 	; Second argument (RDX) is stack pointer, which is also the location of the general purpose registers
 	mov rdx, rsp
 
+	; Save XMM registers. The stack must be 16-byte aligned
+	; or a #GP exception is generated.
+	sub rsp, 68h
+	movaps xmmword ptr [rsp], xmm0
+	movaps xmmword ptr [rsp + 10h], xmm1
+	movaps xmmword ptr [rsp + 20h], xmm2
+	movaps xmmword ptr [rsp + 30h], xmm3
+	movaps xmmword ptr [rsp + 40h], xmm4
+	movaps xmmword ptr [rsp + 50h], xmm5
+
 	; Call HvHandleVmExit to actually handle the
 	; incoming exit
 	sub rsp, 20h
 	call HvHandleVmExit
 	add rsp, 20h
+
+	; Restore SSE registers
+	movaps xmm0, xmmword ptr [rsp]
+	movaps xmm1, xmmword ptr [rsp + 10h]
+	movaps xmm2, xmmword ptr [rsp + 20h]
+	movaps xmm3, xmmword ptr [rsp + 30h]
+	movaps xmm4, xmmword ptr [rsp + 40h]
+	movaps xmm5, xmmword ptr [rsp + 50h]
+	add rsp, 68h
 
 	; If it's not successful, we need to stop and figure out why
 	test al, al


### PR DESCRIPTION
- Adding saving of XMM registers between exits.
- Simplified the logic in NtCreateFileHook. The changed logic also removes a bug I experienced due to reading memory outside of the allocated pool. This is because `wcsstr(kObjectName.Buffer, L"test.txt")` assumes the buffer in a `UNICODE_STRING` is null-terminated, which isn't guaranteed to be true.
- Updated the IA-32 submodule because the code doesn't compile right out of the box due to a reference to a renamed constant.
- Added newlines to each log as WinDBG doesn't append newlines to log entries by default.