### PR TITLE
BUG HvEptHookWriteAbsoluteJump and HvEptHookInstructionMemory

### DIFF
--- a/gbhv/ept.c
+++ b/gbhv/ept.c
@@ -634,7 +634,7 @@ BOOL HvEptHookInstructionMemory(PVMM_EPT_PAGE_HOOK Hook, PVOID TargetFunction, P
 	OffsetIntoPage = ADDRMASK_EPT_PML1_OFFSET((SIZE_T)TargetFunction);
 	HvUtilLogDebug("OffsetIntoPage: 0x%llx\n", OffsetIntoPage);
 
-	if ((OffsetIntoPage + 13) > PAGE_SIZE-1)
+	if ((OffsetIntoPage + 14) > PAGE_SIZE-1)
 	{
 		HvUtilLogError("Function extends past a page boundary. We just don't have the technology to solve this.....\n");
 		return FALSE;
@@ -642,7 +642,7 @@ BOOL HvEptHookInstructionMemory(PVMM_EPT_PAGE_HOOK Hook, PVOID TargetFunction, P
 
 	/* Determine the number of instructions necessary to overwrite using Length Disassembler Engine */
 	for(SizeOfHookedInstructions = 0; 
-		SizeOfHookedInstructions < 13; 
+		SizeOfHookedInstructions < 14; 
 		SizeOfHookedInstructions += LDE((PCHAR)TargetFunction + SizeOfHookedInstructions, 64))
 	{
 		// Get the full size of instructions necessary to copy
@@ -653,7 +653,7 @@ BOOL HvEptHookInstructionMemory(PVMM_EPT_PAGE_HOOK Hook, PVOID TargetFunction, P
 	/* Build a trampoline */
 	
 	/* Allocate some executable memory for the trampoline */
-	Hook->Trampoline = OsAllocateExecutableNonpagedMemory(SizeOfHookedInstructions + 13);
+	Hook->Trampoline = OsAllocateExecutableNonpagedMemory(SizeOfHookedInstructions + 14);
 
 	if (!Hook->Trampoline)
 	{

--- a/gbhv/vmxdefs.asm
+++ b/gbhv/vmxdefs.asm
@@ -125,9 +125,13 @@ HvEnterFromGuest PROC
 
 	; Save XMM registers. The stack must be 16-byte aligned
 	; or a #GP exception is generated.
-	; 520 = 512(fxsave need) + 8
-	sub rsp, 520
-    	fxsave [rsp]
+	sub rsp, 68h
+	movaps xmmword ptr [rsp], xmm0
+	movaps xmmword ptr [rsp+10h], xmm1
+	movaps xmmword ptr [rsp+20h], xmm2
+	movaps xmmword ptr [rsp+30h], xmm3
+	movaps xmmword ptr [rsp+40h], xmm4
+	movaps xmmword ptr [rsp+50h], xmm5
 
 	; Call HvHandleVmExit to actually handle the
 	; incoming exit
@@ -136,8 +140,13 @@ HvEnterFromGuest PROC
 	add rsp, 20h
 
 	; Restore XMM registers
-	fxrstor [rsp]
-	add rsp, 520
+	movaps xmm0, xmmword ptr [rsp]
+	movaps xmm1, xmmword ptr [rsp+10h]
+	movaps xmm2, xmmword ptr [rsp+20h]
+	movaps xmm3, xmmword ptr [rsp+30h]
+	movaps xmm4, xmmword ptr [rsp+40h]
+	movaps xmm5, xmmword ptr [rsp+50h]
+	add rsp, 68h
 
 	; If it's not successful, we need to stop and figure out why
 	test al, al

--- a/gbhv/vmxdefs.asm
+++ b/gbhv/vmxdefs.asm
@@ -125,13 +125,9 @@ HvEnterFromGuest PROC
 
 	; Save XMM registers. The stack must be 16-byte aligned
 	; or a #GP exception is generated.
-	sub rsp, 68h
-	movaps xmmword ptr [rsp], xmm0
-	movaps xmmword ptr [rsp+10h], xmm1
-	movaps xmmword ptr [rsp+20h], xmm2
-	movaps xmmword ptr [rsp+30h], xmm3
-	movaps xmmword ptr [rsp+40h], xmm4
-	movaps xmmword ptr [rsp+50h], xmm5
+	; 520 = 512(fxsave need) + 8
+	sub rsp, 520
+    	fxsave [rsp]
 
 	; Call HvHandleVmExit to actually handle the
 	; incoming exit
@@ -140,13 +136,8 @@ HvEnterFromGuest PROC
 	add rsp, 20h
 
 	; Restore XMM registers
-	movaps xmm0, xmmword ptr [rsp]
-	movaps xmm1, xmmword ptr [rsp+10h]
-	movaps xmm2, xmmword ptr [rsp+20h]
-	movaps xmm3, xmmword ptr [rsp+30h]
-	movaps xmm4, xmmword ptr [rsp+40h]
-	movaps xmm5, xmmword ptr [rsp+50h]
-	add rsp, 68h
+	fxrstor [rsp]
+	add rsp, 520
 
 	; If it's not successful, we need to stop and figure out why
 	test al, al


### PR DESCRIPTION
It is not safe to use a temporary register without restoring
